### PR TITLE
Fix IPublishedContentInformationExtractor to work when Property Value Converters are enabled

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Tea Commerce
+Copyright (c) 2019 Outfield Digital Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,32 @@
 # Tea Commerce for Umbraco
-Tea Commerce is a powerful e-commerce platform for Umbraco CMS. It's fast to implement, easy to use and flexible for growth. Learn more about this [umbraco ecommerce](http://teacommerce.net) project at the Tea Commerce website.
+Tea Commerce is a powerful e-commerce platform for Umbraco CMS. It's fast to implement, easy to use and flexible for growth. Learn more about this [umbraco ecommerce](https://teacommerce.net/) project at the Tea Commerce website.
 
 ## What Tea Commerce does for you
+Tea Commerce gives you the tools as a developer to implement an e-commerce site using Umbraco CMS. The DX experience has been a major factor in the development of the API you use to implement the shop. Tea Commerce processes orders, manages VAT/taxes, handles shipping, sends out order confirmation emails to the customers etc. While this is handles by Tea Commerce, Umbraco is used to handle product categories, products, variants, related products etc. The combination of Tea Commerce and Umbraco gives you the flexibility to build a store in any imagineable way on a robust platform, capable of handling small and large store sizes.
 
 ## Features
+Tea Commerce comes with all the basic features you need to run a successfull e-commerce business, but it's built so developers can expand on it. Here's what you get out of the box:
++ Handle products, variants, related products using Umbraco
++ Unlimited number of stores with unique styling and checkout flow
++ Multiple currencies
++ Marketing (time limited campaigns, discount codes, unit price discount, free shipping etc.)
++ Order management
++ Handle international VAT
++ 20+ payment gateways (ePay, PayPal, Stripe, AuthorizeNet, Klarna, Ogone etc.)
++ International shipping
++ Security permissions per user
+
+## Demo
+It's really simple to try Tea Commerce or show it off to a client. Just go to the [demo website](https://demo.teacommerce.net/) and give it a go. You can also access the Umbraco back-office and see how the platform works from a shop owners point of view. The source code of the demo solution is available here at [GitHub](https://github.com/TeaCommerce/Starter-kit-for-Umbraco).
 
 ## Downloading
-You can download Tea Commerce for Umbraco at the [our.umbraco.org](https://our.umbraco.org/projects/website-utilities/tea-commerce) portal
+You can download Tea Commerce for Umbraco at the [our.umbraco.org](https://our.umbraco.org/projects/website-utilities/tea-commerce) portal.
 
 ## Documentation
-Go to Tea Commerce's [documentation portal](http://documentation.teacommerce.net) for further details about the software and how to use it.
+Go to Tea Commerce's [documentation portal](https://documentation.teacommerce.net/) for further details about the software and how to use it.
 
 ##Support
-The Tea Commerce team is more than happy to help you! Whether it is a question about implementation, use of the system or possibilities with Tea Commerce. Learn more about this posibility at the [Tea Commerce website](http://teacommerce.net). You can also ask the friendly Umbraco community your questions at the [support forum](https://our.umbraco.org/projects/website-utilities/tea-commerce/tea-commerce-support).
+The Tea Commerce team is more than happy to help you! Whether it is a question about implementation, use of the system or possibilities with Tea Commerce. Learn more about this posibility at the [Tea Commerce website](https://teacommerce.net/). You can also ask the friendly Umbraco community your questions at the [support forum](https://our.umbraco.org/projects/website-utilities/tea-commerce/tea-commerce-support).
 
 ##Contribute
 If you want to help - GREAT! You can contribute directly to the project here at GitHub. All help is greatly appreciated, both pull requests, bug reporting, enhancements etc. The employees from [webbureau](https://teasolutions.dk/) Tea Solutions is already contributing.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 Tea Commerce is a powerful e-commerce platform for Umbraco CMS. It's fast to implement, easy to use and flexible for growth. Learn more about this [umbraco ecommerce](https://teacommerce.net/) project at the Tea Commerce website.
 
 ## What Tea Commerce does for you
-Tea Commerce gives you the tools as a developer to implement an e-commerce site using Umbraco CMS. The DX experience has been a major factor in the development of the API you use to implement the shop.
-Tea Commerce processes orders, manages VAT/taxes, handles shipping, sends out order confirmation emails to the customers etc. While this is handles by Tea Commerce, Umbraco is used to handle product categories, products, variants, related products etc. The combination of Tea Commerce and Umbraco gives you the flexibility to build a store in any imagineable way on a robust platform, capable of handling small and large store sizes.
+Tea Commerce gives you the tools as a developer to implement an e-commerce site using Umbraco CMS. The DX experience has been a major factor in the development of the API you use to implement the shop. Tea Commerce processes orders, manages VAT/taxes, handles shipping, sends out order confirmation emails to the customers etc. While this is handles by Tea Commerce, Umbraco is used to handle product categories, products, variants, related products etc. The combination of Tea Commerce and Umbraco gives you the flexibility to build a store in any imagineable way on a robust platform, capable of handling small and large store sizes.
 
 ## Features
 Tea Commerce comes with all the basic features you need to run a successfull e-commerce business, but it's built so developers can expand on it. Here's what you get out of the box:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Tea Commerce is a powerful e-commerce platform for Umbraco CMS. It's fast to implement, easy to use and flexible for growth. Learn more about this [umbraco ecommerce](https://teacommerce.net/) project at the Tea Commerce website.
 
 ## What Tea Commerce does for you
-Tea Commerce gives you the tools as a developer to implement an e-commerce site using Umbraco CMS. The DX experience has been a major factor in the development of the API you use to implement the shop. Tea Commerce processes orders, manages VAT/taxes, handles shipping, sends out order confirmation emails to the customers etc. While this is handles by Tea Commerce, Umbraco is used to handle product categories, products, variants, related products etc. The combination of Tea Commerce and Umbraco gives you the flexibility to build a store in any imagineable way on a robust platform, capable of handling small and large store sizes.
+Tea Commerce gives you the tools as a developer to implement an e-commerce site using Umbraco CMS. The DX experience has been a major factor in the development of the API you use to implement the shop.
+Tea Commerce processes orders, manages VAT/taxes, handles shipping, sends out order confirmation emails to the customers etc. While this is handles by Tea Commerce, Umbraco is used to handle product categories, products, variants, related products etc. The combination of Tea Commerce and Umbraco gives you the flexibility to build a store in any imagineable way on a robust platform, capable of handling small and large store sizes.
 
 ## Features
 Tea Commerce comes with all the basic features you need to run a successfull e-commerce business, but it's built so developers can expand on it. Here's what you get out of the box:

--- a/Source/TeaCommerce.Umbraco.Configuration/InformationExtractors/PublishedContentProductInformationExtractor.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/InformationExtractors/PublishedContentProductInformationExtractor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using TeaCommerce.Api.Common;
@@ -235,10 +236,18 @@ namespace TeaCommerce.Umbraco.Configuration.InformationExtractors {
           if ( CheckNullOrEmpty( rtnValue ) ) {
 
             //Check if we can find a master relation
-            string masterRelationNodeId = GetPropertyValueInternal<string>( product, Constants.ProductPropertyAliases.MasterRelationPropertyAlias, recursive );
-            if ( !string.IsNullOrEmpty( masterRelationNodeId ) && UmbracoHelper != null ) {
-              rtnValue = GetPropertyValue<T>( UmbracoHelper.TypedContent( masterRelationNodeId ), propertyAlias,
-                variant, func );
+            var masterRelation = this.GetPropertyValueInternal<IEnumerable<IPublishedContent>>(product, Constants.ProductPropertyAliases.MasterRelationPropertyAlias, recursive)?.FirstOrDefault();
+            if (masterRelation == null)
+            {
+              //fall back to string
+              string masterRelationNodeId = GetPropertyValueInternal<string>(product, Constants.ProductPropertyAliases.MasterRelationPropertyAlias, recursive);
+              if (!string.IsNullOrWhiteSpace(masterRelationNodeId))
+              {
+                masterRelation = UmbracoHelper.TypedContent(masterRelationNodeId);
+              }
+            }
+            if (masterRelation != null && UmbracoHelper != null ) {
+              rtnValue = GetPropertyValue<T>(masterRelation, propertyAlias, variant, func );
             }
           }
 


### PR DESCRIPTION
Fixes #63

This fixes the PublishedContentProductInformationExtractor  so that it can handle getting an IEnumerable<IPublishedContent> for the master relation, as is default on Umbraco 7.6+. It will fall back to the old string method if the value received is null (which might be due to property value converters disabled or on previous Umbraco Versions.

I have tested with EnablePropertyValueConverters both true and false, but only on Umbraco 7.13.2.