### PR TITLE
Enable using Partial Views in TemplateRenderer and TemplateFileLocator

### DIFF
--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateFileLocator.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateFileLocator.cs
@@ -14,6 +14,8 @@ namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
       string basePath = HostingEnvironment.MapPath( "~" );
       templateFiles.AddRange( GetTemplateFilesFromDir( basePath, HostingEnvironment.MapPath( SystemDirectories.MacroScripts ), "*.cshtml" ) );
       templateFiles.AddRange( GetTemplateFilesFromDir( basePath, HostingEnvironment.MapPath( SystemDirectories.MacroScripts ), "*.vbhtml" ) );
+      //Add partial views
+      templateFiles.AddRange( GetTemplateFilesFromDir( basePath, HostingEnvironment.MapPath( SystemDirectories.MvcViews ) + "\\Partials", "*.cshtml"));
 
       return templateFiles;
     }
@@ -45,7 +47,14 @@ namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
 
         if ( templateFile.EndsWith( ".xslt" ) && !templateFile.StartsWith( SystemDirectories.Xslt.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) ) ) ) {
           templateFile = templateFile.Replace( "~", SystemDirectories.Xslt );
-        } else if ( ( templateFile.EndsWith( ".cshtml" ) || templateFile.EndsWith( ".vbhtml" ) ) && !templateFile.StartsWith( SystemDirectories.MacroScripts.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) ) ) ) {
+        }
+        else if (templateFile.StartsWith("~\\Partials"))
+        {
+           templateFile = templateFile.Replace("~\\", SystemDirectories.MvcViews + "/");
+                }
+        else if ( ( templateFile.EndsWith( ".cshtml" ) || templateFile.EndsWith( ".vbhtml" ) ) &&
+                    !templateFile.StartsWith( SystemDirectories.MvcViews.Replace("/", new string(Path.DirectorySeparatorChar, 1))) &&
+                    !templateFile.StartsWith( SystemDirectories.MacroScripts.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) ) ) ) {
           templateFile = templateFile.Replace( "~", SystemDirectories.MacroScripts );
         }
         templateFile = templateFile.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) );

--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateFileLocator.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateFileLocator.cs
@@ -48,10 +48,10 @@ namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
         if ( templateFile.EndsWith( ".xslt" ) && !templateFile.StartsWith( SystemDirectories.Xslt.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) ) ) ) {
           templateFile = templateFile.Replace( "~", SystemDirectories.Xslt );
         }
-        else if (templateFile.StartsWith("~\\Partials"))
+        else if (templateFile.EndsWith(".cshtml") && templateFile.StartsWith("~\\Partials"))
         {
            templateFile = templateFile.Replace("~\\", SystemDirectories.MvcViews + "/");
-                }
+        }
         else if ( ( templateFile.EndsWith( ".cshtml" ) || templateFile.EndsWith( ".vbhtml" ) ) &&
                     !templateFile.StartsWith( SystemDirectories.MvcViews.Replace("/", new string(Path.DirectorySeparatorChar, 1))) &&
                     !templateFile.StartsWith( SystemDirectories.MacroScripts.Replace( "/", new string( Path.DirectorySeparatorChar, 1 ) ) ) ) {

--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateRenderer.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateRenderer.cs
@@ -64,7 +64,7 @@ namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
       templateFile = _templateFileLocator.TranslateTemplateFileLocation( templateFile );
 
       if ( !string.IsNullOrEmpty( templateFile ) && File.Exists( HostingEnvironment.MapPath( templateFile ) ) && ( templateFile.EndsWith( ".cshtml" ) || templateFile.EndsWith( ".vbhtml" ) ) ) {
-        if (templateFile.Replace("\\", "/").StartsWith(SystemDirectories.MvcViews))
+        if (templateFile.Replace("\\", "/").StartsWith(SystemDirectories.MvcViews + "/Partials"))
         {
            if(model != null)
            {

--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateRenderer.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/TemplateRenderer.cs
@@ -17,6 +17,7 @@ using umbraco.cms.businesslogic.language;
 using umbraco.cms.businesslogic.macro;
 using umbraco.MacroEngines;
 using umbraco.NodeFactory;
+using Umbraco.Web;
 
 namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
   public class TemplateRenderer : ITemplateRenderer {
@@ -63,7 +64,23 @@ namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating {
       templateFile = _templateFileLocator.TranslateTemplateFileLocation( templateFile );
 
       if ( !string.IsNullOrEmpty( templateFile ) && File.Exists( HostingEnvironment.MapPath( templateFile ) ) && ( templateFile.EndsWith( ".cshtml" ) || templateFile.EndsWith( ".vbhtml" ) ) ) {
-        rtnStr = RenderRazorFile( templateFile, pageId, model );
+        if (templateFile.Replace("\\", "/").StartsWith(SystemDirectories.MvcViews))
+        {
+           if(model != null)
+           {
+              rtnStr = ViewRenderer.RenderPartialView(templateFile, model);
+           }
+           else
+           {
+              //If we don't have a model passed in, we pass the current page as model, as this is what happens normally in Umbraco
+              var content = UmbracoContext.Current.ContentCache.GetById(int.Parse(pageId.ToString()));
+              rtnStr = ViewRenderer.RenderPartialView(templateFile, content);
+           }
+         }
+         else
+         {
+             rtnStr = RenderRazorFile(templateFile, pageId, model);
+         }
       }
 
       Thread.CurrentThread.CurrentUICulture = currentUiCulture;

--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/ViewRenderer.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/ViewRenderer.cs
@@ -1,0 +1,367 @@
+﻿using System;
+using System.Web;
+using System.Web.Mvc;
+using System.IO;
+using System.Web.Routing;
+
+namespace TeaCommerce.Umbraco.Configuration.Infrastructure.Templating
+{
+    /// <summary>
+    /// Class that renders MVC views to a string using the
+    /// standard MVC View Engine to render the view. 
+    /// 
+    /// Requires that ASP.NET HttpContext is present to
+    /// work, but works outside of the context of MVC
+    /// </summary>
+    internal class ViewRenderer
+    {
+        /// <summary>
+        /// Required Controller Context
+        /// </summary>
+        protected ControllerContext Context { get; set; }
+
+        /// <summary>
+        /// Initializes the ViewRenderer with a Context.
+        /// </summary>
+        /// <param name="controllerContext">
+        /// If you are running within the context of an ASP.NET MVC request pass in
+        /// the controller's context. 
+        /// Only leave out the context if no context is otherwise available.
+        /// </param>
+        public ViewRenderer(ControllerContext controllerContext = null)
+        {
+            // Create a known controller from HttpContext if no context is passed
+            if (controllerContext == null)
+            {
+                if (HttpContext.Current != null)
+                    controllerContext = CreateController<EmptyController>().ControllerContext;
+                else
+                    throw new InvalidOperationException(
+                        "ViewRenderer must run in the context of an ASP.NET " +
+                        "Application and requires HttpContext.Current to be present.");
+            }
+            Context = controllerContext;
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a string. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout        
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to render the view with</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public string RenderViewToString(string viewPath, object model = null)
+        {
+            return RenderViewToStringInternal(viewPath, model, false);
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a writer. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout        
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to render the view with</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public void RenderView(string viewPath, object model, TextWriter writer)
+        {
+            RenderViewToWriterInternal(viewPath, writer, model, false);
+        }
+
+
+        /// <summary>
+        /// Renders a partial MVC view to string. Use this method to render
+        /// a partial view that doesn't merge with _Layout and doesn't fire
+        /// _ViewStart.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public string RenderPartialViewToString(string viewPath, object model = null)
+        {
+            return RenderViewToStringInternal(viewPath, model, true);
+        }
+
+        /// <summary>
+        /// Renders a partial MVC view to given Writer. Use this method to render
+        /// a partial view that doesn't merge with _Layout and doesn't fire
+        /// _ViewStart.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="writer">Writer to render the view to</param>
+        public void RenderPartialView(string viewPath, object model, TextWriter writer)
+        {
+            RenderViewToWriterInternal(viewPath, writer, model, true);
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a writer. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="controllerContext">Active Controller context</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public static string RenderView(string viewPath, object model = null,
+                                        ControllerContext controllerContext = null)
+        {
+            ViewRenderer renderer = new ViewRenderer(controllerContext);
+            return renderer.RenderViewToString(viewPath, model);
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a writer. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="writer">Writer to render the view to</param>
+        /// <param name="controllerContext">Active Controller context</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public static void RenderView(string viewPath, TextWriter writer, object model,
+                                        ControllerContext controllerContext)
+        {
+            ViewRenderer renderer = new ViewRenderer(controllerContext);
+            renderer.RenderView(viewPath, model, writer);
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a writer. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="controllerContext">Active Controller context</param>
+        /// <param name="errorMessage">optional out parameter that captures an error message instead of throwing</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public static string RenderView(string viewPath, object model,
+                                        ControllerContext controllerContext,
+                                        out string errorMessage)
+        {
+            errorMessage = null;
+            try
+            {
+                ViewRenderer renderer = new ViewRenderer(controllerContext);
+                return renderer.RenderViewToString(viewPath, model);
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.GetBaseException().Message;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Renders a full MVC view to a writer. Will render with the full MVC
+        /// View engine including running _ViewStart and merging into _Layout
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="controllerContext">Active Controller context</param>
+        /// <param name="writer">Writer to render the view to</param>
+        /// <param name="errorMessage">optional out parameter that captures an error message instead of throwing</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public static void RenderView(string viewPath, object model, TextWriter writer,
+                                        ControllerContext controllerContext,
+                                        out string errorMessage)
+        {
+            errorMessage = null;
+            try
+            {
+                ViewRenderer renderer = new ViewRenderer(controllerContext);
+                renderer.RenderView(viewPath, model, writer);
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.GetBaseException().Message;
+            }
+        }
+
+
+        /// <summary>
+        /// Renders a partial MVC view to string. Use this method to render
+        /// a partial view that doesn't merge with _Layout and doesn't fire
+        /// _ViewStart.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="controllerContext">Active controller context</param>
+        /// <returns>String of the rendered view or null on error</returns>
+        public static string RenderPartialView(string viewPath, object model = null,
+                                                ControllerContext controllerContext = null)
+        {
+            ViewRenderer renderer = new ViewRenderer(controllerContext);
+            return renderer.RenderPartialViewToString(viewPath, model);
+        }
+
+        /// <summary>
+        /// Renders a partial MVC view to string. Use this method to render
+        /// a partial view that doesn't merge with _Layout and doesn't fire
+        /// _ViewStart.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">The model to pass to the viewRenderer</param>
+        /// <param name="controllerContext">Active controller context</param>
+        /// <param name="writer">Text writer to render view to</param>
+        /// <param name="errorMessage">optional output parameter to receive an error message on failure</param>
+        public static void RenderPartialView(string viewPath, TextWriter writer, object model = null,
+                                                ControllerContext controllerContext = null)
+        {
+            ViewRenderer renderer = new ViewRenderer(controllerContext);
+            renderer.RenderPartialView(viewPath, model, writer);
+        }
+
+
+        /// <summary>
+        /// Internal method that handles rendering of either partial or 
+        /// or full views.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">Model to render the view with</param>
+        /// <param name="partial">Determines whether to render a full or partial view</param>
+        /// <param name="writer">Text writer to render view to</param>
+        protected void RenderViewToWriterInternal(string viewPath, TextWriter writer, object model = null, bool partial = false)
+        {
+            // first find the ViewEngine for this view
+            ViewEngineResult viewEngineResult = null;
+            if (partial)
+                viewEngineResult = ViewEngines.Engines.FindPartialView(Context, viewPath);
+            else
+                viewEngineResult = ViewEngines.Engines.FindView(Context, viewPath, null);
+
+            if (viewEngineResult == null)
+                throw new FileNotFoundException();
+
+            // get the view and attach the model to view data
+            var view = viewEngineResult.View;
+            Context.Controller.ViewData.Model = model;
+
+            var ctx = new ViewContext(Context, view,
+                                        Context.Controller.ViewData,
+                                        Context.Controller.TempData,
+                                        writer);
+            view.Render(ctx, writer);
+        }
+
+        /// <summary>
+        /// Internal method that handles rendering of either partial or 
+        /// or full views.
+        /// </summary>
+        /// <param name="viewPath">
+        /// The path to the view to render. Either in same controller, shared by 
+        /// name or as fully qualified ~/ path including extension
+        /// </param>
+        /// <param name="model">Model to render the view with</param>
+        /// <param name="partial">Determines whether to render a full or partial view</param>
+        /// <returns>String of the rendered view</returns>
+        private string RenderViewToStringInternal(string viewPath, object model,
+                                                    bool partial = false)
+        {
+            // first find the ViewEngine for this view
+            ViewEngineResult viewEngineResult = null;
+            if (partial)
+                viewEngineResult = ViewEngines.Engines.FindPartialView(Context, viewPath);
+            else
+                viewEngineResult = ViewEngines.Engines.FindView(Context, viewPath, null);
+
+            if (viewEngineResult == null || viewEngineResult.View == null)
+                throw new FileNotFoundException("View not found");
+
+            // get the view and attach the model to view data
+            var view = viewEngineResult.View;
+            Context.Controller.ViewData.Model = model;
+
+            string result = null;
+
+            using (var sw = new StringWriter())
+            {
+                var ctx = new ViewContext(Context, view,
+                                            Context.Controller.ViewData,
+                                            Context.Controller.TempData,
+                                            sw);
+                view.Render(ctx, sw);
+                result = sw.ToString();
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Creates an instance of an MVC controller from scratch 
+        /// when no existing ControllerContext is present       
+        /// </summary>
+        /// <typeparam name="T">Type of the controller to create</typeparam>
+        /// <returns>Controller for T</returns>
+        /// <exception cref="InvalidOperationException">thrown if HttpContext not available</exception>
+        public static T CreateController<T>(RouteData routeData = null, params object[] parameters)
+                    where T : Controller, new()
+        {
+            // create a disconnected controller instance
+            T controller = (T)Activator.CreateInstance(typeof(T), parameters);
+
+            // get context wrapper from HttpContext if available
+            HttpContextBase wrapper = null;
+            if (HttpContext.Current != null)
+                wrapper = new HttpContextWrapper(System.Web.HttpContext.Current);
+            else
+                throw new InvalidOperationException(
+                    "Can't create Controller Context if no active HttpContext instance is available.");
+
+            if (routeData == null)
+                routeData = new RouteData();
+
+            // add the controller routing if not existing
+            if (!routeData.Values.ContainsKey("controller") && !routeData.Values.ContainsKey("Controller"))
+                routeData.Values.Add("controller", controller.GetType().Name
+                                                            .ToLower()
+                                                            .Replace("controller", ""));
+
+            controller.ControllerContext = new ControllerContext(wrapper, routeData, controller);
+            return controller;
+        }
+
+    }
+
+    /// <summary>
+    /// Empty MVC Controller instance used to 
+    /// instantiate and provide a new ControllerContext
+    /// for the ViewRenderer
+    /// </summary>
+    public class EmptyController : Controller
+    {
+    }
+}

--- a/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/ViewRenderer.cs
+++ b/Source/TeaCommerce.Umbraco.Configuration/Infrastructure/Templating/ViewRenderer.cs
@@ -1,4 +1,35 @@
-﻿using System;
+﻿/*
+ **************************************************************
+ *  Author: Rick Strahl 
+ *          © West Wind Technologies, 2008 2011
+ *          http://www.west-wind.com/
+ * 
+ * Created: 09/04/2008
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ **************************************************************  
+*/
+
+using System;
 using System.Web;
 using System.Web.Mvc;
 using System.IO;

--- a/Source/TeaCommerce.Umbraco.Configuration/TeaCommerce.Umbraco.Configuration.csproj
+++ b/Source/TeaCommerce.Umbraco.Configuration/TeaCommerce.Umbraco.Configuration.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Infrastructure\Templating\TemplateContext.cs" />
     <Compile Include="Infrastructure\Templating\TemplateFileLocator.cs" />
     <Compile Include="Infrastructure\Templating\TemplateRenderer.cs" />
+    <Compile Include="Infrastructure\Templating\ViewRenderer.cs" />
     <Compile Include="Marketing\AutofacModules\ServicesConfig.cs" />
     <Compile Include="Marketing\Models\Awards\OrderLineAmountAward.cs" />
     <Compile Include="Marketing\Models\Editor.cs" />


### PR DESCRIPTION
Fixes #79

This PR enabled TeaCommerce to render Partial Views when rerendering dynamically (for instance when changing a variant on a product page).

This PR allows you to reference a partial view like this:
```
<div id="product" refreshwithtemplate="Partials/ProductView.cshtml" class="@cssClass" nodeId="@product.Id" itemscope="" itemtype="http://schema.org/Product">
```

If the view name is prefixed with `Partials/` it will be treated as an MVC Partial View. Otherwise the code will fall back to macroScripts, so that it is backwards compatible. I have tested with both macroScripts and Partial Views and both work fine.

The TemplateFileLocator has been updated to also show partial views in the UI tab in store settings so they can be chosen for rendering, just like macroScripts.

The TemplateRenderer has been updated to detect if the path starts with `~/Views` and render an MVC partial instead of a macroScript. 

In both classes I would have liked to use the `SystemDirectories.PartialViews` property, but this was added in a later Umbraco version, so I had to settle for `SystemDirectories.MvcViews` instead.
I have only used the .cshtml extension, as I don't believe Umbraco supports .vbhtml MVC views at all.

The ViewRenderer class comes from here: https://github.com/RickStrahl/WestwindToolkit. This project is MIT licensed, so there should be no problem including this code.

I have tried to keep the very weird code formatting going on in these files, though I would have liked to reformat them with proper spacing and indentation.