### PR TITLE
Update data type install task to support inserting with fixed IDs/Guids

### DIFF
--- a/Source/TeaCommerce.Umbraco.Install/InstallTasks/ADbInstallTask.cs
+++ b/Source/TeaCommerce.Umbraco.Install/InstallTasks/ADbInstallTask.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Umbraco.Core;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace TeaCommerce.Umbraco.Install.InstallTasks
+{
+    public abstract class ADbInstallTask : IInstallTask
+    {
+        protected UmbracoDatabase Database => ApplicationContext.Current.DatabaseContext.Database;
+
+        protected ISqlSyntaxProvider SqlSyntax = SqlSyntaxContext.SqlSyntaxProvider;
+
+        public abstract void Install();
+
+        public abstract void Uninstall();
+
+        protected void WithIdentityInsert(string tableName, Action act)
+        {
+            if (SqlSyntax.SupportsIdentityInsert())
+                Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} ON ", SqlSyntax.GetQuotedTableName(tableName))));
+
+            act.Invoke();
+
+            if (SqlSyntax.SupportsIdentityInsert())
+                Database.Execute(new Sql(string.Format("SET IDENTITY_INSERT {0} OFF ", SqlSyntax.GetQuotedTableName(tableName))));
+        }
+    }
+}

--- a/Source/TeaCommerce.Umbraco.Install/InstallTasks/AUmbracoDbInstallTask.cs
+++ b/Source/TeaCommerce.Umbraco.Install/InstallTasks/AUmbracoDbInstallTask.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.Persistence.SqlSyntax;
 
 namespace TeaCommerce.Umbraco.Install.InstallTasks
 {
-    public abstract class ADbInstallTask : IInstallTask
+    public abstract class AUmbracoDbInstallTask : IInstallTask
     {
         protected UmbracoDatabase Database => ApplicationContext.Current.DatabaseContext.Database;
 

--- a/Source/TeaCommerce.Umbraco.Install/InstallTasks/DataTypeDefinitionInstallTask.cs
+++ b/Source/TeaCommerce.Umbraco.Install/InstallTasks/DataTypeDefinitionInstallTask.cs
@@ -5,7 +5,7 @@ using Umbraco.Core.Models;
 
 namespace TeaCommerce.Umbraco.Install.InstallTasks
 {
-    public class DataTypeDefinitionInstallTask : ADbInstallTask
+    public class DataTypeDefinitionInstallTask : AUmbracoDbInstallTask
     {
         private readonly int _id;
         private readonly Guid _key;
@@ -29,15 +29,20 @@ namespace TeaCommerce.Umbraco.Install.InstallTasks
 
             if (!dataTypeDefinitions.Any())
             {
-                WithIdentityInsert("umbracoNode", () =>
+                using (var transaction = Database.GetTransaction())
                 {
-                    Database.Insert("umbracoNode", "id", false, new { id = _id, trashed = false, parentID = -1, nodeUser = 0, level = 0, path = "-1,"+ _id, sortOrder = 0, uniqueID = _key, text = _name, nodeObjectType = new Guid(Constants.ObjectTypes.DataType), createDate = DateTime.Now });
-                });
+                    WithIdentityInsert("umbracoNode", () =>
+                    {
+                        Database.Insert("umbracoNode", "id", false, new { id = _id, trashed = false, parentID = -1, nodeUser = 0, level = 0, path = "-1," + _id, sortOrder = 0, uniqueID = _key, text = _name, nodeObjectType = new Guid(Constants.ObjectTypes.DataType), createDate = DateTime.Now });
+                    });
 
-                WithIdentityInsert("cmsDataType", () =>
-                {
-                    Database.Insert("cmsDataType", "pk", false, new { pk = _id, nodeId = _id, propertyEditorAlias = _propertyEditorAlias, dbType = _dbType.ToString() });
-                });
+                    WithIdentityInsert("cmsDataType", () =>
+                    {
+                        Database.Insert("cmsDataType", "pk", false, new { pk = _id, nodeId = _id, propertyEditorAlias = _propertyEditorAlias, dbType = _dbType.ToString() });
+                    });
+
+                    transaction.Complete();
+                }
             }
         }
 

--- a/Source/TeaCommerce.Umbraco.Install/InstallTasks/DataTypeDefinitionInstallTask.cs
+++ b/Source/TeaCommerce.Umbraco.Install/InstallTasks/DataTypeDefinitionInstallTask.cs
@@ -1,36 +1,55 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 
-namespace TeaCommerce.Umbraco.Install.InstallTasks {
-  public class DataTypeDefinitionInstallTask : IInstallTask {
+namespace TeaCommerce.Umbraco.Install.InstallTasks
+{
+    public class DataTypeDefinitionInstallTask : ADbInstallTask
+    {
+        private readonly int _id;
+        private readonly Guid _key;
+        private readonly string _name;
+        private readonly string _propertyEditorAlias;
+        private readonly DataTypeDatabaseType _dbType;
 
-    private readonly string _name;
-    private readonly string _propertyEditorAlias;
+        public DataTypeDefinitionInstallTask(int id, Guid key, string name, string propertyEditorAlias, DataTypeDatabaseType dbType)
+        {
+            _id = id;
+            _key = key;
+            _name = name;
+            _propertyEditorAlias = propertyEditorAlias;
+            _dbType = dbType;
+        }
 
-    public DataTypeDefinitionInstallTask(string name, string propertyEditorAlias) {
-      _name = name;
-      _propertyEditorAlias = propertyEditorAlias;
+        public override void Install()
+        {
+            var dataTypeDefinitions = ApplicationContext.Current.Services.DataTypeService
+                .GetDataTypeDefinitionByPropertyEditorAlias(_propertyEditorAlias);
+
+            if (!dataTypeDefinitions.Any())
+            {
+                WithIdentityInsert("umbracoNode", () =>
+                {
+                    Database.Insert("umbracoNode", "id", false, new { id = _id, trashed = false, parentID = -1, nodeUser = 0, level = 0, path = "-1,"+ _id, sortOrder = 0, uniqueID = _key, text = _name, nodeObjectType = new Guid(Constants.ObjectTypes.DataType), createDate = DateTime.Now });
+                });
+
+                WithIdentityInsert("cmsDataType", () =>
+                {
+                    Database.Insert("cmsDataType", "pk", false, new { pk = _id, nodeId = _id, propertyEditorAlias = _propertyEditorAlias, dbType = _dbType.ToString() });
+                });
+            }
+        }
+
+        public override void Uninstall()
+        {
+            var dataTypeDefinitions = ApplicationContext.Current.Services.DataTypeService
+                .GetDataTypeDefinitionByPropertyEditorAlias(_propertyEditorAlias);
+
+            foreach (IDataTypeDefinition dataTypeDefinition in dataTypeDefinitions)
+            {
+                ApplicationContext.Current.Services.DataTypeService.Delete(dataTypeDefinition);
+            }
+        }
     }
-
-    public void Install() {
-      IEnumerable<IDataTypeDefinition> dataTypeDefinitions = ApplicationContext.Current.Services.DataTypeService.GetDataTypeDefinitionByPropertyEditorAlias( _propertyEditorAlias );
-      if ( !dataTypeDefinitions.Any() ) {
-        DataTypeDefinition dataTypeDefinition = new DataTypeDefinition( -1, _propertyEditorAlias ) {
-          Name = _name,
-          DatabaseType = _propertyEditorAlias != "TeaCommerce.StockManagement" ? DataTypeDatabaseType.Integer : DataTypeDatabaseType.Nvarchar
-        };
-        ApplicationContext.Current.Services.DataTypeService.Save( dataTypeDefinition );
-      }
-    }
-
-    public void Uninstall() {
-      IEnumerable<IDataTypeDefinition> dataTypeDefinitions = ApplicationContext.Current.Services.DataTypeService.GetDataTypeDefinitionByPropertyEditorAlias( _propertyEditorAlias );
-
-      foreach ( IDataTypeDefinition dataTypeDefinition in dataTypeDefinitions ) {
-        ApplicationContext.Current.Services.DataTypeService.Delete( dataTypeDefinition );
-      }
-    }
-  }
 }

--- a/Source/TeaCommerce.Umbraco.Install/Installer.cs
+++ b/Source/TeaCommerce.Umbraco.Install/Installer.cs
@@ -10,251 +10,283 @@ using TeaCommerce.Api.Persistence;
 using TeaCommerce.Api.Persistence.Installation;
 using TeaCommerce.Api.Services;
 using TeaCommerce.Umbraco.Install.InstallTasks;
+using Umbraco.Core.Models;
 
-namespace TeaCommerce.Umbraco.Install {
-  public class Installer : IInstaller {
+namespace TeaCommerce.Umbraco.Install
+{
+    public class Installer : IInstaller
+    {
 
-    private readonly IDatabaseFactory _databaseFactory;
-    private readonly PersistenceInstaller _persistenceInstaller;
-    private readonly IStoreService _storeService;
-    private readonly IPaymentMethodService _paymentMethodService;
-    private readonly IOrderService _orderService;
+        private readonly IDatabaseFactory _databaseFactory;
+        private readonly PersistenceInstaller _persistenceInstaller;
+        private readonly IStoreService _storeService;
+        private readonly IPaymentMethodService _paymentMethodService;
+        private readonly IOrderService _orderService;
 
-    private readonly IList<IInstallTask> _installTasks;
+        private readonly IList<IInstallTask> _installTasks;
 
-    public Installer( IDatabaseFactory databaseFactory, IStoreService storeService, IPaymentMethodService paymentMethodService, IOrderService orderService ) {
-      _databaseFactory = databaseFactory;
-      _storeService = storeService;
-      _paymentMethodService = paymentMethodService;
-      _orderService = orderService;
-      _persistenceInstaller = new PersistenceInstaller( databaseFactory );
-
-      _installTasks = new List<IInstallTask>();
-
-      //Sections
-      _installTasks.Add( new SectionInstallTask( "Tea Commerce", "teacommerce", "icon-shopping-basket-alt-2" ) );
-
-      //Trees
-      _installTasks.Add( new ApplicationTreeInstallTask( "tea-commerce-store-tree", "Stores", 0, "TeaCommerce.Umbraco.Application.Trees.StoreTree,TeaCommerce.Umbraco.Application" ) );
-      _installTasks.Add( new ApplicationTreeInstallTask( "tea-commerce-security-tree", "Security", 1, "TeaCommerce.Umbraco.Application.Trees.SecurityTree,TeaCommerce.Umbraco.Application" ) );
-      _installTasks.Add( new ApplicationTreeInstallTask( "tea-commerce-licenses-tree", "Licenses", 2, "TeaCommerce.Umbraco.Application.Trees.LicenseTree,TeaCommerce.Umbraco.Application" ) );
-      _installTasks.Add( new ApplicationTreeInstallTask( "tea-commerce-need-help-tree", "Need help?", 3, "TeaCommerce.Umbraco.Application.Trees.NeedHelpTree,TeaCommerce.Umbraco.Application" ) );
-
-      //Grant permissions
-      _installTasks.Add( new GrantPermissionsInstallTask() );
-
-      //Misc files
-      _installTasks.Add( new MoveFileInstallTask( "~/macroScripts/tea-commerce/email-template-confirmation.cshtml.default", "~/macroScripts/tea-commerce/email-template-confirmation.cshtml" ) { OverwriteFile = false } );
-      _installTasks.Add( new MoveFileInstallTask( "~/macroScripts/tea-commerce/email-template-payment-inconsistency.cshtml.default", "~/macroScripts/tea-commerce/email-template-payment-inconsistency.cshtml" ) { OverwriteFile = false } );
-      _installTasks.Add( new MoveFileInstallTask( "~/macroScripts/tea-commerce/edit-order.cshtml.default", "~/macroScripts/tea-commerce/edit-order.cshtml" ) { OverwriteFile = false } );
-
-      //Data type definitions
-      _installTasks.Add( new DataTypeDefinitionInstallTask( "Tea Commerce: Store picker", "TeaCommerce.StorePicker" ) );
-      _installTasks.Add( new DataTypeDefinitionInstallTask( "Tea Commerce: VAT group picker", "TeaCommerce.VatGroupPicker" ) );
-      _installTasks.Add( new DataTypeDefinitionInstallTask( "Tea Commerce: Stock management", "TeaCommerce.StockManagement" ) );
-      _installTasks.Add( new DataTypeDefinitionInstallTask( "Tea Commerce: Variant Editor", "TeaCommerce.VariantEditor" ) );
-
-    }
-
-    public void InstallOrUpdate() {
-      _persistenceInstaller.InstallOrUpdate();
-
-      Database database = _databaseFactory.Get();
-
-      int currentVersion = database.ExecuteScalar<int>( "SELECT SpecialActionsVersion FROM TeaCommerce_Version" );
-      int stepTargetVersion = 0;
-      int targetVersion = 5;
-
-      // Loop from the current version to the target version 
-      // one step at a time, performing any upgrade steps. 
-      // At each step we also update the SpecialActionsVersion 
-      // in the TeaCommerce_Version database table. 
-      // If any step fails, we log the failure, but carry on 
-      // to the next step.
-      while ( currentVersion < targetVersion) {
-        try
+        public Installer(IDatabaseFactory databaseFactory, IStoreService storeService, IPaymentMethodService paymentMethodService, IOrderService orderService)
         {
-          stepTargetVersion = currentVersion + 1;
+            _databaseFactory = databaseFactory;
+            _storeService = storeService;
+            _paymentMethodService = paymentMethodService;
+            _orderService = orderService;
+            _persistenceInstaller = new PersistenceInstaller(databaseFactory);
 
-          #region Initial install
+            _installTasks = new List<IInstallTask>();
 
-          if ( currentVersion == 0 ) {
-            foreach ( IInstallTask installTask in _installTasks ) {
-              installTask.Install();
-            }
-          }
+            //Sections
+            _installTasks.Add(new SectionInstallTask("Tea Commerce", "teacommerce", "icon-shopping-basket-alt-2"));
 
-          #endregion
+            //Trees
+            _installTasks.Add(new ApplicationTreeInstallTask("tea-commerce-store-tree", "Stores", 0, "TeaCommerce.Umbraco.Application.Trees.StoreTree,TeaCommerce.Umbraco.Application"));
+            _installTasks.Add(new ApplicationTreeInstallTask("tea-commerce-security-tree", "Security", 1, "TeaCommerce.Umbraco.Application.Trees.SecurityTree,TeaCommerce.Umbraco.Application"));
+            _installTasks.Add(new ApplicationTreeInstallTask("tea-commerce-licenses-tree", "Licenses", 2, "TeaCommerce.Umbraco.Application.Trees.LicenseTree,TeaCommerce.Umbraco.Application"));
+            _installTasks.Add(new ApplicationTreeInstallTask("tea-commerce-need-help-tree", "Need help?", 3, "TeaCommerce.Umbraco.Application.Trees.NeedHelpTree,TeaCommerce.Umbraco.Application"));
 
-          #region 2.1.0
+            //Grant permissions
+            _installTasks.Add(new GrantPermissionsInstallTask());
 
-          if ( stepTargetVersion == 1 ) {
-            #region Auto set current cart and order number for all stores
-            foreach ( Store store in _storeService.GetAll() ) {
-              store.CurrentCartNumber = database.ExecuteScalar<long>( "SELECT COUNT(Id) FROM TeaCommerce_Order WHERE StoreId=@0", store.Id );
-              store.CurrentOrderNumber = database.ExecuteScalar<long>( "SELECT COUNT(Id) FROM TeaCommerce_Order WHERE StoreId=@0 AND DateFinalized IS NOT NULL", store.Id );
-              store.Save();
-            }
-            #endregion
-          }
+            //Misc files
+            _installTasks.Add(new MoveFileInstallTask("~/macroScripts/tea-commerce/email-template-confirmation.cshtml.default", "~/macroScripts/tea-commerce/email-template-confirmation.cshtml") { OverwriteFile = false });
+            _installTasks.Add(new MoveFileInstallTask("~/macroScripts/tea-commerce/email-template-payment-inconsistency.cshtml.default", "~/macroScripts/tea-commerce/email-template-payment-inconsistency.cshtml") { OverwriteFile = false });
+            _installTasks.Add(new MoveFileInstallTask("~/macroScripts/tea-commerce/edit-order.cshtml.default", "~/macroScripts/tea-commerce/edit-order.cshtml") { OverwriteFile = false });
 
-          #endregion
+            //Data type definitions
+            _installTasks.Add(new DataTypeDefinitionInstallTask(-544300, new Guid("d4537677-950d-42cc-a4f7-6e9f5b2c0d63"), "Tea Commerce: Store picker", "TeaCommerce.StorePicker", DataTypeDatabaseType.Integer));
+            _installTasks.Add(new DataTypeDefinitionInstallTask(-544301, new Guid("6be44a64-f431-472c-b639-0335843ce82d3"), "Tea Commerce: VAT group picker", "TeaCommerce.VatGroupPicker", DataTypeDatabaseType.Nvarchar));
+            _installTasks.Add(new DataTypeDefinitionInstallTask(-544302, new Guid("bb82164e-20f6-4506-a401-67042cb5e5e8"), "Tea Commerce: Stock management", "TeaCommerce.StockManagement", DataTypeDatabaseType.Nvarchar));
+            _installTasks.Add(new DataTypeDefinitionInstallTask(-544303, new Guid("47c336e8-f1c2-4603-b9c2-a96bae156112"), "Tea Commerce: Variant Editor", "TeaCommerce.VariantEditor", DataTypeDatabaseType.Nvarchar));
 
-          #region 2.1.1
-
-          if ( stepTargetVersion == 2 ) {
-            #region Correct wrong order properties for sage pay orders
-            foreach ( Store store in _storeService.GetAll() ) {
-              List<long> sagePayPaymentMethodIds = _paymentMethodService.GetAll( store.Id ).Where( p => p.PaymentProviderAlias == "SagePay" ).Select( p => p.Id ).ToList();
-
-              if ( sagePayPaymentMethodIds.Any() ) {
-                IEnumerable<Order> orders = _orderService.Get( store.Id, database.Fetch<Guid>( "SELECT Id FROM TeaCommerce_Order WHERE StoreId=@0 AND PaymentMethodId IN (" + string.Join( ",", sagePayPaymentMethodIds ) + ")", store.Id ) );
-
-                foreach ( Order order in orders ) {
-                  CustomProperty vendorTxCode = order.Properties.Get( "VendorTxCode" );
-                  CustomProperty txAuthNo = order.Properties.Get( "TxAuthNo" );
-
-                  if ( vendorTxCode == null && txAuthNo == null ) continue;
-
-                  if ( vendorTxCode != null ) {
-                    vendorTxCode.Alias = "vendorTxCode";
-                  }
-
-                  if ( txAuthNo != null ) {
-                    txAuthNo.Alias = "txAuthNo";
-                  }
-
-                  order.Save();
-                }
-              }
-            }
-            #endregion
-          }
-
-          #endregion
-
-          #region 2.2
-
-          if ( stepTargetVersion == 3 ) {
-            //Had to remove the deletion of TeaCommerce.PaymentProviders.dll and TeaCommerce.PaymentProviders.XmlSerializers.dll
-          }
-
-          #endregion
-
-          #region 2.3.2
-
-          if ( stepTargetVersion == 3 ) {
-            #region Remove order xml cache because properties was wrongly serialized
-            string teaCommerceAppDataPath = HostingEnvironment.MapPath( "~/App_Data/tea-commerce" );
-            if ( teaCommerceAppDataPath != null ) {
-              DirectoryInfo teaCommerceAppDataFolder = new DirectoryInfo( teaCommerceAppDataPath );
-              if ( teaCommerceAppDataFolder.Exists ) {
-                foreach ( FileInfo orderXmlCache in teaCommerceAppDataFolder.GetFiles( "finalized-orders-xml-cache*" ) ) {
-                  orderXmlCache.Delete();
-                }
-              }
-            }
-            #endregion
-          }
-
-          #endregion
-
-          #region 3.0.0
-
-          if ( stepTargetVersion == 4 ) {
-            #region Remove old javascript API file
-            string javaScriptApiFile = HostingEnvironment.MapPath( "~/scripts/tea-commerce.min.js" );
-            if ( javaScriptApiFile != null && File.Exists( javaScriptApiFile ) ) {
-              File.Delete( javaScriptApiFile );
-            }
-            #endregion
-
-            #region Remove old Tea Commerce folder in Umbraco plugins
-            string oldTeaCommercePluginPath = HostingEnvironment.MapPath( "~/umbraco/plugins/tea-commerce" );
-            if ( oldTeaCommercePluginPath != null && Directory.Exists( oldTeaCommercePluginPath ) ) {
-              Directory.Delete( oldTeaCommercePluginPath, true );
-            }
-            oldTeaCommercePluginPath = HostingEnvironment.MapPath( "~/App_Plugins/tea-commerce" );
-            if ( oldTeaCommercePluginPath != null && Directory.Exists( oldTeaCommercePluginPath ) ) {
-              Directory.Delete( oldTeaCommercePluginPath, true );
-            }
-            #endregion
-
-            #region Create default gift card settings
-
-            foreach ( Store store in _storeService.GetAll() ) {
-              store.GiftCardSettings.Length = 10;
-              store.GiftCardSettings.DaysValid = 1095;
-              store.Save();
-            }
-
-            #endregion
-          }
-
-          #endregion
-
-          #region 3.3.0
-
-          // We were going to attempt to delete payment provider 3rd party DLL's
-          // but on second thoughs, we decided to leave them and add nodes in the 
-          // changelog as it's not detramental if they remain, but could cause
-          // problems if the app pool recycles mid delete
-          //
-          //if ( stepTargetVersion == 6 )
-          //{
-          //  #region Remove old payment provider dependencies
-
-          //  // The latest payment provider build merges 3rd party dependencies
-          //  // into the core payment providers DLL in order to prevent conflicts
-
-          //  var oldPaymentProvider3rdPartyDlls = new string [] {
-          //    "Klarna.Checkout.dll",
-          //    "Paynova.Api.Client.dll",
-          //    "Stripe.net.dll"
-          //  };
-
-          //  foreach (var dll in oldPaymentProvider3rdPartyDlls)
-          //  {
-          //    var dllPath = HostingEnvironment.MapPath("~/bin/" + dll);
-          //    if (dllPath != null && File.Exists(dllPath))
-          //    {
-          //      File.Delete(dllPath);
-          //    }
-          //  }
-
-          //  #endregion
-          //}
-
-          #endregion
-          
-          database.Execute( "UPDATE TeaCommerce_Version SET SpecialActionsVersion=@0", stepTargetVersion );
-        } catch ( Exception exp ) {
-          LoggingService.Instance.Error<Installer>( $"Tea Commerce upgrade step {stepTargetVersion} failed", exp );
-          break;
-        } finally {
-          // Update current version whether a step succeeds or fails
-          currentVersion = stepTargetVersion;
         }
-      }
 
-      //Language files
-      new LanguageFileInstallTask( "TeaCommerce.Umbraco.Install.Content.Resources.da.xml", "~/umbraco/config/lang/da.xml" ).Install();
-      new LanguageFileInstallTask( "TeaCommerce.Umbraco.Install.Content.Resources.en.xml", "~/umbraco/config/lang/en.xml" ).Install();
-      new LanguageFileInstallTask( "TeaCommerce.Umbraco.Install.Content.Resources.en_us.xml", "~/umbraco/config/lang/en_us.xml" ).Install();
-      new LanguageFileInstallTask( "TeaCommerce.Umbraco.Install.Content.Resources.se.xml", "~/umbraco/config/lang/se.xml" ).Install();
-      new UIFileInstallTask( "TeaCommerce.Umbraco.Install.Content.XML.UI.xml", "~/umbraco/config/create/UI.xml" ).Install();
+        public void InstallOrUpdate()
+        {
+            _persistenceInstaller.InstallOrUpdate();
 
-      //Fix package file
-      new RemoveOldPackageInstallTask().Install();
+            Database database = _databaseFactory.Get();
 
+            int currentVersion = database.ExecuteScalar<int>("SELECT SpecialActionsVersion FROM TeaCommerce_Version");
+            int stepTargetVersion = 0;
+            int targetVersion = 5;
+
+            // Loop from the current version to the target version 
+            // one step at a time, performing any upgrade steps. 
+            // At each step we also update the SpecialActionsVersion 
+            // in the TeaCommerce_Version database table. 
+            // If any step fails, we log the failure, but carry on 
+            // to the next step.
+            while (currentVersion < targetVersion)
+            {
+                try
+                {
+                    stepTargetVersion = currentVersion + 1;
+
+                    #region Initial install
+
+                    if (currentVersion == 0)
+                    {
+                        foreach (IInstallTask installTask in _installTasks)
+                        {
+                            installTask.Install();
+                        }
+                    }
+
+                    #endregion
+
+                    #region 2.1.0
+
+                    if (stepTargetVersion == 1)
+                    {
+                        #region Auto set current cart and order number for all stores
+                        foreach (Store store in _storeService.GetAll())
+                        {
+                            store.CurrentCartNumber = database.ExecuteScalar<long>("SELECT COUNT(Id) FROM TeaCommerce_Order WHERE StoreId=@0", store.Id);
+                            store.CurrentOrderNumber = database.ExecuteScalar<long>("SELECT COUNT(Id) FROM TeaCommerce_Order WHERE StoreId=@0 AND DateFinalized IS NOT NULL", store.Id);
+                            store.Save();
+                        }
+                        #endregion
+                    }
+
+                    #endregion
+
+                    #region 2.1.1
+
+                    if (stepTargetVersion == 2)
+                    {
+                        #region Correct wrong order properties for sage pay orders
+                        foreach (Store store in _storeService.GetAll())
+                        {
+                            List<long> sagePayPaymentMethodIds = _paymentMethodService.GetAll(store.Id).Where(p => p.PaymentProviderAlias == "SagePay").Select(p => p.Id).ToList();
+
+                            if (sagePayPaymentMethodIds.Any())
+                            {
+                                IEnumerable<Order> orders = _orderService.Get(store.Id, database.Fetch<Guid>("SELECT Id FROM TeaCommerce_Order WHERE StoreId=@0 AND PaymentMethodId IN (" + string.Join(",", sagePayPaymentMethodIds) + ")", store.Id));
+
+                                foreach (Order order in orders)
+                                {
+                                    CustomProperty vendorTxCode = order.Properties.Get("VendorTxCode");
+                                    CustomProperty txAuthNo = order.Properties.Get("TxAuthNo");
+
+                                    if (vendorTxCode == null && txAuthNo == null) continue;
+
+                                    if (vendorTxCode != null)
+                                    {
+                                        vendorTxCode.Alias = "vendorTxCode";
+                                    }
+
+                                    if (txAuthNo != null)
+                                    {
+                                        txAuthNo.Alias = "txAuthNo";
+                                    }
+
+                                    order.Save();
+                                }
+                            }
+                        }
+                        #endregion
+                    }
+
+                    #endregion
+
+                    #region 2.2
+
+                    if (stepTargetVersion == 3)
+                    {
+                        //Had to remove the deletion of TeaCommerce.PaymentProviders.dll and TeaCommerce.PaymentProviders.XmlSerializers.dll
+                    }
+
+                    #endregion
+
+                    #region 2.3.2
+
+                    if (stepTargetVersion == 3)
+                    {
+                        #region Remove order xml cache because properties was wrongly serialized
+                        string teaCommerceAppDataPath = HostingEnvironment.MapPath("~/App_Data/tea-commerce");
+                        if (teaCommerceAppDataPath != null)
+                        {
+                            DirectoryInfo teaCommerceAppDataFolder = new DirectoryInfo(teaCommerceAppDataPath);
+                            if (teaCommerceAppDataFolder.Exists)
+                            {
+                                foreach (FileInfo orderXmlCache in teaCommerceAppDataFolder.GetFiles("finalized-orders-xml-cache*"))
+                                {
+                                    orderXmlCache.Delete();
+                                }
+                            }
+                        }
+                        #endregion
+                    }
+
+                    #endregion
+
+                    #region 3.0.0
+
+                    if (stepTargetVersion == 4)
+                    {
+                        #region Remove old javascript API file
+                        string javaScriptApiFile = HostingEnvironment.MapPath("~/scripts/tea-commerce.min.js");
+                        if (javaScriptApiFile != null && System.IO.File.Exists(javaScriptApiFile))
+                        {
+                            System.IO.File.Delete(javaScriptApiFile);
+                        }
+                        #endregion
+
+                        #region Remove old Tea Commerce folder in Umbraco plugins
+                        string oldTeaCommercePluginPath = HostingEnvironment.MapPath("~/umbraco/plugins/tea-commerce");
+                        if (oldTeaCommercePluginPath != null && Directory.Exists(oldTeaCommercePluginPath))
+                        {
+                            Directory.Delete(oldTeaCommercePluginPath, true);
+                        }
+                        oldTeaCommercePluginPath = HostingEnvironment.MapPath("~/App_Plugins/tea-commerce");
+                        if (oldTeaCommercePluginPath != null && Directory.Exists(oldTeaCommercePluginPath))
+                        {
+                            Directory.Delete(oldTeaCommercePluginPath, true);
+                        }
+                        #endregion
+
+                        #region Create default gift card settings
+
+                        foreach (Store store in _storeService.GetAll())
+                        {
+                            store.GiftCardSettings.Length = 10;
+                            store.GiftCardSettings.DaysValid = 1095;
+                            store.Save();
+                        }
+
+                        #endregion
+                    }
+
+                    #endregion
+
+                    #region 3.3.0
+
+                    // We were going to attempt to delete payment provider 3rd party DLL's
+                    // but on second thoughs, we decided to leave them and add nodes in the 
+                    // changelog as it's not detramental if they remain, but could cause
+                    // problems if the app pool recycles mid delete
+                    //
+                    //if ( stepTargetVersion == 6 )
+                    //{
+                    //  #region Remove old payment provider dependencies
+
+                    //  // The latest payment provider build merges 3rd party dependencies
+                    //  // into the core payment providers DLL in order to prevent conflicts
+
+                    //  var oldPaymentProvider3rdPartyDlls = new string [] {
+                    //    "Klarna.Checkout.dll",
+                    //    "Paynova.Api.Client.dll",
+                    //    "Stripe.net.dll"
+                    //  };
+
+                    //  foreach (var dll in oldPaymentProvider3rdPartyDlls)
+                    //  {
+                    //    var dllPath = HostingEnvironment.MapPath("~/bin/" + dll);
+                    //    if (dllPath != null && File.Exists(dllPath))
+                    //    {
+                    //      File.Delete(dllPath);
+                    //    }
+                    //  }
+
+                    //  #endregion
+                    //}
+
+                    #endregion
+
+                    database.Execute("UPDATE TeaCommerce_Version SET SpecialActionsVersion=@0", stepTargetVersion);
+                }
+                catch (Exception exp)
+                {
+                    LoggingService.Instance.Error<Installer>($"Tea Commerce upgrade step {stepTargetVersion} failed", exp);
+                    break;
+                }
+                finally
+                {
+                    // Update current version whether a step succeeds or fails
+                    currentVersion = stepTargetVersion;
+                }
+            }
+
+            //Language files
+            new LanguageFileInstallTask("TeaCommerce.Umbraco.Install.Content.Resources.da.xml", "~/umbraco/config/lang/da.xml").Install();
+            new LanguageFileInstallTask("TeaCommerce.Umbraco.Install.Content.Resources.en.xml", "~/umbraco/config/lang/en.xml").Install();
+            new LanguageFileInstallTask("TeaCommerce.Umbraco.Install.Content.Resources.en_us.xml", "~/umbraco/config/lang/en_us.xml").Install();
+            new LanguageFileInstallTask("TeaCommerce.Umbraco.Install.Content.Resources.se.xml", "~/umbraco/config/lang/se.xml").Install();
+            new UIFileInstallTask("TeaCommerce.Umbraco.Install.Content.XML.UI.xml", "~/umbraco/config/create/UI.xml").Install();
+
+            //Fix package file
+            new RemoveOldPackageInstallTask().Install();
+
+        }
+
+        public void Uninstall()
+        {
+            foreach (IInstallTask installTask in _installTasks)
+            {
+                installTask.Uninstall();
+            }
+
+            _persistenceInstaller.Uninstall();
+        }
     }
-
-    public void Uninstall() {
-      foreach ( IInstallTask installTask in _installTasks ) {
-        installTask.Uninstall();
-      }
-
-      _persistenceInstaller.Uninstall();
-    }
-  }
 }

--- a/Source/TeaCommerce.Umbraco.Install/Installer.cs
+++ b/Source/TeaCommerce.Umbraco.Install/Installer.cs
@@ -54,7 +54,7 @@ namespace TeaCommerce.Umbraco.Install
 
             //Data type definitions
             _installTasks.Add(new DataTypeDefinitionInstallTask(-544300, new Guid("d4537677-950d-42cc-a4f7-6e9f5b2c0d63"), "Tea Commerce: Store picker", "TeaCommerce.StorePicker", DataTypeDatabaseType.Integer));
-            _installTasks.Add(new DataTypeDefinitionInstallTask(-544301, new Guid("6be44a64-f431-472c-b639-0335843ce82d3"), "Tea Commerce: VAT group picker", "TeaCommerce.VatGroupPicker", DataTypeDatabaseType.Nvarchar));
+            _installTasks.Add(new DataTypeDefinitionInstallTask(-544301, new Guid("5438a097-8233-4903-af7a-4a8a2a049381"), "Tea Commerce: VAT group picker", "TeaCommerce.VatGroupPicker", DataTypeDatabaseType.Nvarchar));
             _installTasks.Add(new DataTypeDefinitionInstallTask(-544302, new Guid("bb82164e-20f6-4506-a401-67042cb5e5e8"), "Tea Commerce: Stock management", "TeaCommerce.StockManagement", DataTypeDatabaseType.Nvarchar));
             _installTasks.Add(new DataTypeDefinitionInstallTask(-544303, new Guid("47c336e8-f1c2-4603-b9c2-a96bae156112"), "Tea Commerce: Variant Editor", "TeaCommerce.VariantEditor", DataTypeDatabaseType.Nvarchar));
 

--- a/Source/TeaCommerce.Umbraco.Install/TeaCommerce.Umbraco.Install.csproj
+++ b/Source/TeaCommerce.Umbraco.Install/TeaCommerce.Umbraco.Install.csproj
@@ -97,6 +97,7 @@
   <ItemGroup>
     <Compile Include="AutofacModules\InfrastructureConfig.cs" />
     <Compile Include="Installer.cs" />
+    <Compile Include="InstallTasks\AUmbracoDbInstallTask.cs" />
     <Compile Include="InstallTasks\GrantPermissionsInstallTask.cs" />
     <Compile Include="InstallTasks\MoveFileInstallTask.cs" />
     <Compile Include="InstallTasks\UIFileInstallTask.cs" />
@@ -117,7 +118,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Potential fix for #82 in that this PR would force TC data types to be installed with a fixed ID / Guid and so ID's on local + remote installs would be consistent allowing Umbraco Cloud to sync them correctly.

I'm not an Umbraco cloud expert so not sure if this is the best approach, but I'm guessing given this what core does, it should be ok.

This is currently untested and is just an initial commit for now. Also, there was a lot of whitespace cleanup so unfortunately the diff is a bit screwy, but really the only thing that has changed is `DataTypeDefinitionInstallTask` and it's usage inside `Installer`.