### PR TITLE
Clicking order status goes back (Fixes #95)

### DIFF
--- a/Source/TeaCommerce.Umbraco.Application/Views/Orders/SearchOrders.aspx
+++ b/Source/TeaCommerce.Umbraco.Application/Views/Orders/SearchOrders.aspx
@@ -110,7 +110,7 @@
               <asp:HiddenField ID="HdnId" runat="server" Value='<%# Eval("Id") %>' />
             </td>
             <td>
-              <asp:HyperLink runat="server" Text='<%# (bool)Eval("IsFinalized" ) ? Eval("OrderNumber" ) : Eval("CartNumber" ) %>' NavigateUrl='<%# WebUtils.GetPageUrl( TeaCommerce.Umbraco.Application.Constants.Pages.EditOrder, false ) + "?storeId=" + StoreId + "&id=" + Eval("Id") %>' />
+              <asp:HyperLink runat="server" Text='<%# (bool)Eval("IsFinalized" ) ? Eval("OrderNumber" ) : Eval("CartNumber" ) %>' Target="_top" NavigateUrl='/umbraco/#/teacommerce/framed/<%# HttpUtility.UrlEncode(HttpUtility.UrlEncode( "/umbraco/" + WebUtils.GetPageUrl( TeaCommerce.Umbraco.Application.Constants.Pages.EditOrder, true ) + "?storeId=" + StoreId + "&id=" + Eval("Id"))) %>' />
               <asp:Image ID="ImgExclamation" runat="server" ImageUrl='<%# WebUtils.GetWebResourceUrl( TeaCommerce.Umbraco.Application.Constants.MiscIcons.Exclamation ) %>' Visible='<%# Eval("TransactionInformation.InconsistentPayment") %>' style="position: relative; margin-left: 4px; top: 2px;"/>
             </td>
             <td>


### PR DESCRIPTION
Updated order details list links such that they modify the address bar URL. By doing this, clicking on the order status node in the tree will now actually go back to the order list when in order details view.